### PR TITLE
setting mode 644 on /etc/ssmtp/ssmtp.conf

### DIFF
--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -3,5 +3,5 @@
 
 - name: Install sSMTP packages
   apt: name={{ item }} state=present update_cache=yes
-  with_items: ssmtp_packages
+  with_items: "{{ ssmtp_packages }}"
   tags: ssmtp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,5 +28,5 @@
     dest=/etc/ssmtp/ssmtp.conf
     owner=root
     group=root
-    mode=0640
+    mode=0644
   tags: ssmtp


### PR DESCRIPTION
All users need read access to this file when sending email. Without access,  `/var/log/mail.log` has:
`/etc/ssmtp/ssmtp.conf not found` and `/etc/ssmtp/revaliases` is ignored